### PR TITLE
Add hidden and sub_command_help options

### DIFF
--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -4,7 +4,10 @@ module Commander
   class Command
     attr_accessor :name, :examples, :syntax, :description
     attr_accessor :summary, :proxy_options, :options, :hidden
-    attr_reader :sub_command_help
+    attr_reader :sub_command_group
+
+    alias sub_command= hidden=
+    alias sub_command hidden
 
     ##
     # Options struct.
@@ -147,8 +150,8 @@ module Commander
     # Handles displaying subcommand help. By default it will set the action to 
     # display the subcommand if the action hasn't already been set
 
-    def sub_command_help=(value)
-      @sub_command_help = value
+    def sub_command_group=(value)
+      @sub_command_group = value
       if @when_called.empty?
         self.action {
            exec("#{$0} #{ARGV.join(" ")} --help")

--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -3,7 +3,7 @@ require 'optparse'
 module Commander
   class Command
     attr_accessor :name, :examples, :syntax, :description
-    attr_accessor :summary, :proxy_options, :options
+    attr_accessor :summary, :proxy_options, :options, :hidden
 
     ##
     # Options struct.

--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -4,6 +4,7 @@ module Commander
   class Command
     attr_accessor :name, :examples, :syntax, :description
     attr_accessor :summary, :proxy_options, :options, :hidden
+    attr_reader :sub_command_help
 
     ##
     # Options struct.
@@ -141,6 +142,19 @@ module Commander
       @when_called = block ? [block] : args
     end
     alias action when_called
+
+    ##
+    # Handles displaying subcommand help. By default it will set the action to 
+    # display the subcommand if the action hasn't already been set
+
+    def sub_command_help=(value)
+      @sub_command_help = value
+      if @when_called.empty?
+        self.action {
+           exec("#{$0} #{ARGV.join(" ")} --help")
+        }
+      end
+    end
 
     ##
     # Run the command with _args_.

--- a/lib/commander/help_formatters.rb
+++ b/lib/commander/help_formatters.rb
@@ -9,10 +9,14 @@ module Commander
         @target = target
       end
 
-      def get_binding
-        @target.instance_eval { binding }.tap do |bind|
+      def get_binding(additional = {})
+        bnd = @target.instance_eval { binding }.tap do |bind|
           decorate_binding(bind)
         end
+        additional.each do |k, v|
+          bnd.local_variable_set(k, v)
+        end
+        bnd
       end
 
       # No-op, override in subclasses.

--- a/lib/commander/help_formatters/terminal.rb
+++ b/lib/commander/help_formatters/terminal.rb
@@ -11,6 +11,11 @@ module Commander
         template(:command_help).result(Context.new(command).get_binding)
       end
 
+      def render_subcommand(command)
+        bind = ProgramContext.new(@runner).get_binding({cmd: command})
+        template(:subcommand_help).result(bind)
+      end
+
       def template(name)
         ERB.new(File.read(File.join(File.dirname(__FILE__), 'terminal', "#{name}.erb")), nil, '-')
       end

--- a/lib/commander/help_formatters/terminal/subcommand_help.erb
+++ b/lib/commander/help_formatters/terminal/subcommand_help.erb
@@ -1,0 +1,24 @@
+
+  <%= $terminal.color "NAME", :bold %>:
+
+    <%= cmd.name %>
+<% if @syntax -%>
+
+  <%= $terminal.color "SYNOPSIS", :bold %>:
+
+    <%= cmd.syntax -%>
+
+<% end -%>
+
+  <%= $terminal.color "DESCRIPTION", :bold %>:
+
+    <%= Commander::HelpFormatter.indent 4, (cmd.description || cmd.summary || 'No description.') -%>
+
+
+  <%= $terminal.color "SUBCOMMANDS", :bold %>:
+<% for name, command in @commands.sort -%>
+  <% unless alias? name %>
+    <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] -%>
+  <% end -%>
+<% end %>
+

--- a/lib/commander/help_formatters/terminal_compact/subcommand_help.erb
+++ b/lib/commander/help_formatters/terminal_compact/subcommand_help.erb
@@ -1,0 +1,16 @@
+
+  <%= cmd.name %>
+<% if cmd.syntax -%>
+
+  Usage: <%= cmd.syntax %>
+<% end -%>
+<% if cmd.description || cmd.summary -%>
+
+  <%= cmd.description || cmd.summary %>
+<% end -%>
+
+<% for name, command in @commands.sort -%>
+<% unless alias? name -%>
+    <%= "%-#{max_command_length}s %s" % [command.name, command.summary || command.description] %>
+<% end -%>
+<% end -%>

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -325,7 +325,7 @@ module Commander
             rescue InvalidCommandError => e
               abort "#{e}. Use --help for more information"
             end
-            if command.sub_command_help
+            if command.sub_command_group
               limit_commands_to_subcommands(command)
               say help_formatter.render_subcommand(command)
             else

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -292,7 +292,15 @@ module Commander
     ##
     # Remove hidden commands. Used by the general help
     def remove_hidden_commands
-      @commands.reject! { |k, v| !!v.hidden }
+      commands.reject! { |k, v| !!v.hidden }
+    end
+
+    ##
+    # Limit commands to those which are subcommands of the one that is active
+    def limit_commands_to_subcommands(command)
+      commands.reject! { |k, v|
+        (k.to_s == command.name) ? true : !k.to_s.start_with?("#{command.name} ")
+      }
     end
 
     ##
@@ -317,7 +325,12 @@ module Commander
             rescue InvalidCommandError => e
               abort "#{e}. Use --help for more information"
             end
-            say help_formatter.render_command(command)
+            if command.sub_command_help
+              limit_commands_to_subcommands(command)
+              say help_formatter.render_subcommand(command)
+            else
+              say help_formatter.render_command(command)
+            end
           end
         end
       end

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -290,6 +290,12 @@ module Commander
     end
 
     ##
+    # Remove hidden commands. Used by the general help
+    def remove_hidden_commands
+      @commands.reject! { |k, v| !!v.hidden }
+    end
+
+    ##
     # Creates default commands such as 'help' which is
     # essentially the same as using the --help switch.
 
@@ -302,6 +308,7 @@ module Commander
         c.when_called do |args, _options|
           UI.enable_paging if program(:help_paging)
           if args.empty?
+            remove_hidden_commands
             say help_formatter.render
           else
             command = command args.join(' ')

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '4.4.3'.freeze
+  VERSION = '4.4.4'.freeze
 end


### PR DESCRIPTION
Their are two major changes in this PR that will allow sub command specific help to be created. Please refer to commits for major discussion of changes.

The first change is the introduction of `hidden` commands. When a `Command` is created, if the the hidden method is set to a truthie value, then it will not appear in the general help for the whole command. It will however still have specific command help and may have any action assigned to it.

The second change is `sub_command_help`. If `sub_command_help` is set to a truthie value then instead of rendering the command specific help, a subcommand help page is displayed. It is smilar to the general help, however only lists the subcommands. By default, an action is included that will trigger the help to be displayed even if `--help` is not include. Unfortunately due to the coupling betweeen `Runner` and `Command` objects, the only way I could do this is by exec the command again with the `--help` flag.