### PR TITLE
Add ability to suppress --trace for certain error types

### DIFF
--- a/lib/commander/delegates.rb
+++ b/lib/commander/delegates.rb
@@ -10,7 +10,7 @@ module Commander
       default_command
       always_trace!
       never_trace!
-      suppress_trace_classes
+      suppress_trace_class
     ).each do |meth|
       eval <<-END, binding, __FILE__, __LINE__
         def #{meth}(*args, &block)

--- a/lib/commander/delegates.rb
+++ b/lib/commander/delegates.rb
@@ -10,6 +10,7 @@ module Commander
       default_command
       always_trace!
       never_trace!
+      suppress_trace_message
     ).each do |meth|
       eval <<-END, binding, __FILE__, __LINE__
         def #{meth}(*args, &block)

--- a/lib/commander/delegates.rb
+++ b/lib/commander/delegates.rb
@@ -10,7 +10,7 @@ module Commander
       default_command
       always_trace!
       never_trace!
-      suppress_trace_message
+      suppress_trace_classes
     ).each do |meth|
       eval <<-END, binding, __FILE__, __LINE__
         def #{meth}(*args, &block)

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -95,12 +95,12 @@ module Commander
     # Suppresses the --trace message for these classes
     # However --trace will still display the backtrace if included
 
-    def suppress_trace_classes(*classes)
-      @suppress_trace_classes = classes
+    def suppress_trace_class(*classes)
+      @suppress_trace_class = classes
     end
 
     def suppress_trace_class?(klass)
-      (@suppress_trace_classes || []).any? { |c| klass <= c }
+      (@suppress_trace_class || []).any? { |c| klass <= c }
     end
 
     ##

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -75,7 +75,7 @@ module Commander
           OptionParser::MissingArgument => e
           abort e.to_s
         rescue => e
-          if @never_trace
+          if @never_trace || suppress_trace_class?(e.class)
             abort "error: #{e}."
           else
             abort "error: #{e}. Use --trace to view backtrace"
@@ -95,7 +95,12 @@ module Commander
     # Suppresses the --trace message for these classes
     # However --trace will still display the backtrace if included
 
-    def suppress_trace_message(*error_classes)
+    def suppress_trace_classes(*classes)
+      @suppress_trace_classes = classes
+    end
+
+    def suppress_trace_class?(klass)
+      (@suppress_trace_classes || []).include? klass
     end
 
     ##

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -92,6 +92,13 @@ module Commander
     end
 
     ##
+    # Suppresses the --trace message for these classes
+    # However --trace will still display the backtrace if included
+
+    def suppress_trace_message(*error_classes)
+    end
+
+    ##
     # Enable tracing on all executions (bypasses --trace)
 
     def always_trace!

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -100,7 +100,7 @@ module Commander
     end
 
     def suppress_trace_class?(klass)
-      (@suppress_trace_classes || []).include? klass
+      (@suppress_trace_classes || []).any? { |c| klass <= c }
     end
 
     ##

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -95,12 +95,13 @@ module Commander
     # Suppresses the --trace message for these classes
     # However --trace will still display the backtrace if included
 
-    def suppress_trace_class(*classes)
-      @suppress_trace_class = classes
+    def suppress_trace_class(klass)
+      @suppress_trace_class = klass
     end
 
     def suppress_trace_class?(klass)
-      (@suppress_trace_class || []).any? { |c| klass <= c }
+      return unless @suppress_trace_class
+      klass <= @suppress_trace_class
     end
 
     ##

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '4.5.3'.freeze
+  VERSION = '4.6.0'.freeze
 end

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '4.6.0'.freeze
+  VERSION = '4.4.3-alces0'.freeze
 end

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 
+class InheritedRuntimeError < RuntimeError; end
+
 describe Commander do
   include Commander::Methods
 
@@ -361,11 +363,19 @@ describe Commander do
       msg
     end
 
-    context 'with an error that is suppressed' do
+    shared_examples 'suppresses --trace' do |klass|
       it 'should not display the --trace in the message' do
-        msg = suppress_runtime_error_and_raise RuntimeError
+        msg = suppress_runtime_error_and_raise klass
         expect(msg).not_to match(/--trace/)
       end
+    end
+
+    context 'with an error that is suppressed' do
+      include_examples 'suppresses --trace', RuntimeError
+    end
+
+    context 'with an error that inherits from a suppressed class' do
+      include_examples 'suppresses --trace', InheritedRuntimeError
     end
 
     context 'with an error that is not suppressed' do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -346,6 +346,36 @@ describe Commander do
     end
   end
 
+  describe '#suppress_trace_message' do
+    def suppress_runtime_error_and_raise(error_type)
+      msg = nil
+      begin
+        new_command_runner 'foo' do
+          suppress_trace_message RuntimeError
+          command(:foo) { |c| c.when_called { raise error_type } }
+        end.run!
+      rescue SystemExit => e
+        msg = e.message
+      end
+      expect(msg).to match(/error:/)
+      msg
+    end
+
+    context 'with an error that is suppressed' do
+      it 'should not display the --trace in the message' do
+        msg = suppress_runtime_error_and_raise RuntimeError
+        expect(msg).not_to match(/--trace/)
+      end
+    end
+
+    context 'with an error that is not suppressed' do
+      it 'should display the --trace in the message' do
+        msg = suppress_runtime_error_and_raise StandardError
+        expect(msg).to match(/--trace/)
+      end
+    end
+  end
+
   describe '#always_trace!' do
     it 'should enable tracing globally, regardless of whether --trace was passed or not' do
       expect do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -353,7 +353,7 @@ describe Commander do
       msg = nil
       begin
         new_command_runner 'foo' do
-          suppress_trace_classes RuntimeError
+          suppress_trace_class RuntimeError
           command(:foo) { |c| c.when_called { raise error_type } }
         end.run!
       rescue SystemExit => e

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -351,7 +351,7 @@ describe Commander do
       msg = nil
       begin
         new_command_runner 'foo' do
-          suppress_trace_message RuntimeError
+          suppress_trace_classes RuntimeError
           command(:foo) { |c| c.when_called { raise error_type } }
         end.run!
       rescue SystemExit => e


### PR DESCRIPTION
In some cases we do not want the `--trace` to be printed if there is an error. This is to allow errors to be easily distinguished between `ruby/developer` and `user` errors. The `--trace` option will still display the backtrace regardless. The only change is the user will not always be prompt to use it.

The implementation is fairly straight forward, an array of error types to be suppressed can be configured using `suppress_trace_classes`. This can take multiple error class inputs to be suppressed.

Any errors that inherit from a suppressed class will also be suppressed. This is to make it easier to suppress entire families of classes.

NOTE: The are some failing test that are unrelated to this PR. I have created a card for them
https://trello.com/c/yNAvzwVC/246-fix-commander-errors-due-to-erb-templating