### PR TITLE
Fix bug where sub commands help can not be displayed

### DIFF
--- a/lib/commander/command.rb
+++ b/lib/commander/command.rb
@@ -171,7 +171,7 @@ module Commander
       @sub_command_group = value
       if @when_called.empty?
         self.action {
-           exec("#{$0} #{ARGV.join(" ")} --help")
+          exec("#{$0} #{ARGV.join(" ")} --help")
         }
       end
     end

--- a/lib/commander/patches/validate_inputs.rb
+++ b/lib/commander/patches/validate_inputs.rb
@@ -19,6 +19,7 @@ module Commander
 
       def call(args = [])
         return super unless PatchEnabled
+        return super if syntax_parts[0..1] == ['commander', 'help']
 
         # Use defined syntax to validate how many args this command can be
         # passed.

--- a/lib/commander/version.rb
+++ b/lib/commander/version.rb
@@ -1,3 +1,3 @@
 module Commander
-  VERSION = '4.4.4-alces1'.freeze
+  VERSION = '4.4.4-alces2'.freeze
 end


### PR DESCRIPTION
The integration of checking the inputs has broken the sub commands. This
is because `Commander` reexec a `commander help` command to display the
help pages.

However this internal `Commander` command does not pass the syntax
checking and thus errors. The fix is to not run the validation on this
internal `command`.

Hopefully this works, Commander is confusing AF