### PR TITLE
Replace suppress_trace with silent_trace!

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,6 +435,12 @@ Or make it always on:
 always_trace!
 ```
 
+Include the `--trace` global option but turn off the error message prompt:
+
+```ruby
+silent_trace!
+```
+
 ## Tips
 
 When adding a global or command option, `OptionParser` no longer implicitly adds a small

--- a/lib/commander/delegates.rb
+++ b/lib/commander/delegates.rb
@@ -10,7 +10,7 @@ module Commander
       default_command
       always_trace!
       never_trace!
-      suppress_trace_class
+      silent_trace!
     ).each do |meth|
       eval <<-END, binding, __FILE__, __LINE__
         def #{meth}(*args, &block)

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -93,19 +93,6 @@ module Commander
     end
 
     ##
-    # Suppresses the --trace message for these classes
-    # However --trace will still display the backtrace if included
-
-    def suppress_trace_class(klass)
-      @suppress_trace_class = klass
-    end
-
-    def suppress_trace_class?(klass)
-      return unless @suppress_trace_class
-      klass <= @suppress_trace_class
-    end
-
-    ##
     # Enable tracing on all executions (bypasses --trace)
 
     def always_trace!

--- a/lib/commander/runner.rb
+++ b/lib/commander/runner.rb
@@ -32,6 +32,7 @@ module Commander
       @program = program_defaults
       @always_trace = false
       @never_trace = false
+      @silent_trace = false
       create_default_commands
     end
 
@@ -75,7 +76,7 @@ module Commander
           OptionParser::MissingArgument => e
           abort e.to_s
         rescue => e
-          if @never_trace || suppress_trace_class?(e.class)
+          if @never_trace || @silent_trace
             abort "error: #{e}."
           else
             abort "error: #{e}. Use --trace to view backtrace"
@@ -110,14 +111,25 @@ module Commander
     def always_trace!
       @always_trace = true
       @never_trace = false
+      @silent_trace = false
     end
 
     ##
     # Hide the trace option from the help menus and don't add it as a global option
 
     def never_trace!
-      @never_trace = true
       @always_trace = false
+      @never_trace = true
+      @silent_trace = false
+    end
+
+    ##
+    # Includes the trace option in the help but not in the error message
+
+    def silent_trace!
+      @always_trace = false
+      @never_trace = false
+      @silent_trace = true
     end
 
     ##

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -348,44 +348,6 @@ describe Commander do
     end
   end
 
-  describe '#suppress_trace_message' do
-    def suppress_runtime_error_and_raise(error_type)
-      msg = nil
-      begin
-        new_command_runner 'foo' do
-          suppress_trace_class RuntimeError
-          command(:foo) { |c| c.when_called { raise error_type } }
-        end.run!
-      rescue SystemExit => e
-        msg = e.message
-      end
-      expect(msg).to match(/error:/)
-      msg
-    end
-
-    shared_examples 'suppresses --trace' do |klass|
-      it 'should not display the --trace in the message' do
-        msg = suppress_runtime_error_and_raise klass
-        expect(msg).not_to match(/--trace/)
-      end
-    end
-
-    context 'with an error that is suppressed' do
-      include_examples 'suppresses --trace', RuntimeError
-    end
-
-    context 'with an error that inherits from a suppressed class' do
-      include_examples 'suppresses --trace', InheritedRuntimeError
-    end
-
-    context 'with an error that is not suppressed' do
-      it 'should display the --trace in the message' do
-        msg = suppress_runtime_error_and_raise StandardError
-        expect(msg).to match(/--trace/)
-      end
-    end
-  end
-
   describe '#always_trace!' do
     it 'should enable tracing globally, regardless of whether --trace was passed or not' do
       expect do

--- a/spec/runner_spec.rb
+++ b/spec/runner_spec.rb
@@ -421,6 +421,30 @@ describe Commander do
     end
   end
 
+  describe '#silent_trace!' do
+    it 'should allow the --trace option' do
+      expect do
+        new_command_runner 'help', '--trace' do
+          silent_trace!
+        end.run!
+      end.not_to raise_error
+    end
+
+    it 'should not prompt to use --trace switch on errors' do
+      msg = nil
+      begin
+        new_command_runner 'foo' do
+          silent_trace!
+          command(:foo) { |c| c.when_called { fail 'cookies!' } }
+        end.run!
+      rescue SystemExit => e
+        msg = e.message
+      end
+      expect(msg).to match(/error: cookies!/)
+      expect(msg).not_to match(/--trace/)
+    end
+  end
+
   context 'conflict between #always_trace! and #never_trace!' do
     it 'respects the last used command' do
       expect do


### PR DESCRIPTION
The `--trace` isn't going to be shown with any of the error messages.